### PR TITLE
Calculate z-index for overlay nodes, scene nodes, and connecting edges

### DIFF
--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -244,23 +244,20 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
 
     const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined): number => {
       if (mostRecentlyTouchedSceneIds) {
-        const firstNodeSceneId = mostRecentlyTouchedSceneIds[0];
-        console.log({ firstNodeSceneId})
-        console.log({ nodeIdddddddddddd: id })
-        const relevantSceneNodeId = nodes.find(n => n.id === id)?.parentId;
-        console.log({ relevantSceneNodeId})
-        const isEdgeAtForefront = firstNodeSceneId === relevantSceneNodeId;
-        const isSceneAndFirstNodeSceneId = type === "scene" && firstNodeSceneId === id;
-        console.log({ isEdgeAtForefront })
+        //const firstNodeSceneId = mostRecentlyTouchedSceneIds[0];
+        const parentId = nodes.find(n => n.id === id)?.parentId
+        const relevantSceneNodeId = parentId || id; // if cannot find node parent, that means it's a scene, and this is the scene id;
+        //const isEdgeAtForefront = firstNodeSceneId === relevantSceneNodeId;
+        //const isSceneAndFirstNodeSceneId = type === "scene" && firstNodeSceneId === id;
         const relevantSceneIdIndex = mostRecentlyTouchedSceneIds.findIndex(sceneId => relevantSceneNodeId === sceneId);
-        console.log({ relevantSceneIdIndex })
-        const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => ary.length - idx;
-        console.log({ translateSceneIdIndexToZIndex })
-        const sceneZIndex = (isEdgeAtForefront || isSceneAndFirstNodeSceneId ? 20 : 10) + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex); // nestLevel should be 1
+        const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => idx === -1 ? 0 : ary.length - idx;
+        //const sceneZIndex = (isEdgeAtForefront || isSceneAndFirstNodeSceneId ? 20 : 10) + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex); // nestLevel should be 1
+        const sceneZIndex = (10 + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex) * 10) + (parentId ? 5 : 0); // add +5 for nodes sitting on top of scenes
+        
+        console.log({ id, relevantSceneNodeId, relevantSceneIdIndex, translateSceneIdIndexToZIndex, sceneZIndex })
         //const sceneZIndex = translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex) * 10; // nestLevel should be 1
 
-        console.log({ sceneZIndex})
-        return sceneZIndex - 5; // make sure it's behind the edge
+        return sceneZIndex; // make sure it's behind the edge
       }
       
       return 3;

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -64,6 +64,10 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     const grid = useMemo(() => (snapToGrid ? snapGrid : [1, 1])! as [number, number], [snapToGrid, snapGrid]);
 
     /**
+     * TODO: Ideally this would be using a nested level to determine a z-index, for cases
+     * where there may be more than 2 levels of nodes (not part of the product spec yet but
+     * could be in the future).
+     * 
      * This is calculating z-index styles for overlay nodes and scene nodes.
      * This is calculating scene node z-indexes in increments of 10: 10, 20, 30, 40, etc.
      * Overlay node z-indexes use their parent's scene node z-index, but add an additional 5 because
@@ -75,7 +79,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined): number => {
       if (mostRecentlyTouchedSceneIds) {
         const parentId = nodes.find((n) => n.id === id)?.parentId;
-        const sceneNodeId = type === 'scene' ? id : parentId;
+        const sceneNodeId = parentId || id;
         const sceneIdIndex = mostRecentlyTouchedSceneIds.findIndex((sceneId) => sceneNodeId === sceneId);
 
         /**

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -111,13 +111,13 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
       return 3;
     };
 
-    const calculateZIndexesValue = useMemo(() => calculateZIndexes(mostRecentlyTouchedSceneIds), [
+    const calculatedZIndexValue = useMemo(() => calculateZIndexes(mostRecentlyTouchedSceneIds), [
       mostRecentlyTouchedSceneIds,
     ]);
 
     const nodeStyle: CSSProperties = useMemo(
       () => ({
-        zIndex: calculateZIndexesValue,
+        zIndex: calculatedZIndexValue,
         transform: `translate(${xPos}px,${yPos}px)`,
         pointerEvents:
           isSelectable || isDraggable || onClick || onMouseEnter || onMouseMove || onMouseLeave ? 'all' : 'none',
@@ -137,7 +137,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
         onMouseEnter,
         onMouseMove,
         onMouseLeave,
-        calculateZIndexesValue,
+        calculatedZIndexValue,
       ]
     );
     const onMouseEnterHandler = useMemo(() => {

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -79,7 +79,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined): number => {
       if (mostRecentlyTouchedSceneIds) {
         const parentId = nodes.find((n) => n.id === id)?.parentId;
-        const sceneNodeId = parentId || id;
+        const sceneNodeId = parentId ?? id;
         const sceneIdIndex = mostRecentlyTouchedSceneIds.findIndex((sceneId) => sceneNodeId === sceneId);
 
         /**

--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -49,14 +49,14 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     isDragging,
     resizeObserver,
     children,
-    mostRecentlyTouchedSceneIds
+    mostRecentlyTouchedSceneIds,
   }: React.PropsWithChildren<WrapNodeProps>) => {
     const observerInitialized = useRef<boolean>(false);
     const updateNodeDimensions = useStoreActions((actions) => actions.updateNodeDimensions);
     const addSelectedElements = useStoreActions((actions) => actions.addSelectedElements);
     const updateNodePosDiff = useStoreActions((actions) => actions.updateNodePosDiff);
     const unsetNodesSelection = useStoreActions((actions) => actions.unsetNodesSelection);
-    const nodes = useStoreState(state => state.nodes)
+    const nodes = useStoreState((state) => state.nodes);
 
     const nodeElement = useRef<HTMLDivElement>(null);
 
@@ -66,48 +66,54 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
     /**
      * This is calculating z-index styles for overlay nodes and scene nodes.
      * This is calculating scene node z-indexes in increments of 10: 10, 20, 30, 40, etc.
-     * Overlay node z-indexes use their parent's scene node z-index, but add an additional 5 because 
+     * Overlay node z-indexes use their parent's scene node z-index, but add an additional 5 because
      * we want overlay nodes to sit on top of scene nodes: 15, 25, 35, 45, etc.
      * All scene and overlay nodes that haven't been touched will have z-indexes of 10 and 15, respectively.
      * In case `mostRecentlyTouchedSceneIds` is `undefined`, which we wouldn't expect to happen, just apply a
      * z-index that matches the default z-indexing defined in src/style.css
      */
-     const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined): number => {
+    const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined): number => {
       if (mostRecentlyTouchedSceneIds) {
-        const parentId = nodes.find(n => n.id === id)?.parentId
-        const sceneNodeId = type === "scene" ? id : parentId;
-        const sceneIdIndex = mostRecentlyTouchedSceneIds.findIndex(sceneId => sceneNodeId === sceneId);
+        const parentId = nodes.find((n) => n.id === id)?.parentId;
+        const sceneNodeId = type === 'scene' ? id : parentId;
+        const sceneIdIndex = mostRecentlyTouchedSceneIds.findIndex((sceneId) => sceneNodeId === sceneId);
 
         /**
          * Part 1:
          * First give a default z-index of 10 for every overlay node or scene node that hasn't been touched
          */
-        const baseZIndexForNode = 10
+        const baseZIndexForNode = 10;
 
         /**
          * Part 2:
          * 1. If a scene hasn't been touched yet, it won't appear in `mostRecentlyTouchedSceneIds`, so give these nodes and scene nodes the lowest z-index
-         * 2. Otherwise, a lower `sceneIdIndex` means that that scene has been the more recently touched. So if we subtract that number from number of all 
-         * scene nodes that have been touched and multiply it by 10, we'll get scene z-indexes sequenced in increments of 10. 
+         * 2. Otherwise, a lower `sceneIdIndex` means that that scene has been the more recently touched. So if we subtract that number from number of all
+         * scene nodes that have been touched and multiply it by 10, we'll get scene z-indexes sequenced in increments of 10.
          */
-        const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => idx === -1 ? 0 : (ary.length - idx) * 10;
-        
+        const translateSceneIdIndexToZIndex = (ary: string[], idx: number) =>
+          idx === -1 ? 0 : (ary.length - idx) * 10;
+
         /**
          * Part 3:
          * We want overlay nodes to sit on top of scene nodes, so add an additional 5 to overlay nodes
          */
-        const additionalZIndexForOverlayNodes = parentId ? 5 : 0
+        const additionalZIndexForOverlayNodes = parentId ? 5 : 0;
 
-        const sceneZIndex = baseZIndexForNode + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, sceneIdIndex) + additionalZIndexForOverlayNodes;
+        const sceneZIndex =
+          baseZIndexForNode +
+          translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, sceneIdIndex) +
+          additionalZIndexForOverlayNodes;
 
         return sceneZIndex;
       }
-      
+
       // Default z-index for nodes and edges defined in src/style.css
       return 3;
     };
 
-    const calculateZIndexesValue = useMemo(() => calculateZIndexes(mostRecentlyTouchedSceneIds), [mostRecentlyTouchedSceneIds])
+    const calculateZIndexesValue = useMemo(() => calculateZIndexes(mostRecentlyTouchedSceneIds), [
+      mostRecentlyTouchedSceneIds,
+    ]);
 
     const nodeStyle: CSSProperties = useMemo(
       () => ({
@@ -131,7 +137,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
         onMouseEnter,
         onMouseMove,
         onMouseLeave,
-        calculateZIndexesValue
+        calculateZIndexesValue,
       ]
     );
     const onMouseEnterHandler = useMemo(() => {

--- a/src/components/NodesSelection/index.tsx
+++ b/src/components/NodesSelection/index.tsx
@@ -121,7 +121,7 @@ export default ({
   }
 
   return (
-    <div className="react-flow__nodesselection" style={style /*TODO: put zIndex here*/}>
+    <div className="react-flow__nodesselection" style={style}>
       <ReactDraggable
         scale={tScale}
         grid={grid}

--- a/src/components/NodesSelection/index.tsx
+++ b/src/components/NodesSelection/index.tsx
@@ -15,6 +15,7 @@ export interface NodesSelectionProps {
   onSelectionDrag?: (event: MouseEvent, nodes: Node[]) => void;
   onSelectionDragStop?: (event: MouseEvent, nodes: Node[]) => void;
   onSelectionContextMenu?: (event: MouseEvent, nodes: Node[]) => void;
+  mostRecentlyTouchedSceneIds?: string[];
 }
 
 export default ({
@@ -120,7 +121,7 @@ export default ({
   }
 
   return (
-    <div className="react-flow__nodesselection" style={style}>
+    <div className="react-flow__nodesselection" style={style /*TODO: put zIndex here*/}>
       <ReactDraggable
         scale={tScale}
         grid={grid}

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -248,10 +248,19 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
       // const relevantSceneNodeId = parentId || id; // if cannot find node parent, that means it's a scene, and this is the scene id;
       //const isEdgeAtForefront = firstNodeSceneId === relevantSceneNodeId;
       //const isSceneAndFirstNodeSceneId = type === "scene" && firstNodeSceneId === id;
-      const relevantSceneIdIndex = Math.min(...parentIds.map(parentId => mostRecentlyTouchedSceneIds.findIndex(sceneId => parentId === sceneId)));
+      const aryForMathMin = new Set(parentIds.map(parentId => mostRecentlyTouchedSceneIds.findIndex(sceneId => parentId === sceneId)));
+      // I
+      const relevantSceneIdIndex = () => {
+        if (aryForMathMin.has(-1) && aryForMathMin.size > 1) {
+          aryForMathMin.delete(-1);
+        } 
+        
+        return Math.min(...aryForMathMin)
+      };
+      // const relevantSceneIdIndex = Math.min(...parentIds.map(parentId => mostRecentlyTouchedSceneIds.findIndex(sceneId => parentId === sceneId)));
       const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => idx === -1 ? 0 : ary.length - idx;
       //const sceneZIndex = (isEdgeAtForefront || isSceneAndFirstNodeSceneId ? 20 : 10) + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex); // nestLevel should be 1
-      const sceneZIndex = (10 + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex) * 10) + 5; // add +5 for nodes sitting on top of scenes
+      const sceneZIndex = (10 + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex()) * 10) + 5; // add +5 for nodes sitting on top of scenes
       console.log("THIS IS INSIDE EDGE RENDERER")
       console.log({ parentIds, relevantSceneIdIndex, sceneZIndex })
       return sceneZIndex;

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -145,6 +145,8 @@ const Edge = ({
 
   const isSelected = selectedElements?.some((elm) => isEdge(elm) && elm.id === edge.id) || false;
 
+  console.log({ edgeStyle: edge.style })
+
   return (
     <EdgeComponent
       key={edge.id}
@@ -161,7 +163,7 @@ const Edge = ({
       labelBgStyle={edge.labelBgStyle}
       labelBgPadding={edge.labelBgPadding}
       labelBgBorderRadius={edge.labelBgBorderRadius}
-      style={edge.style}
+      style={{...edge.style, zIndex: 10000000}}
       arrowHeadType={edge.arrowHeadType}
       source={edge.source}
       target={edge.target}
@@ -220,12 +222,18 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   } = props;
   const transformStyle = `translate(${transform[0]},${transform[1]}) scale(${transform[2]})`;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
+  //console.log({ state })
+  //const isParentedSceneSelected = 
+  //const zIndex = (selected ? 10 : 3) + (10 * nestLevel)
 
   return (
-    <svg width={width} height={height} className="react-flow__edges">
+    <div>
+        {edges.map((edge: Edge) => {
+          console.log({ iAmEdge: edge, edge, edgeProps: props});
+          return (
+            <svg width={width} height={height} className="react-flow__edges" style={{zIndex: 5}}>
       <MarkerDefinitions color={arrowHeadColor} />
       <g transform={transformStyle}>
-        {edges.map((edge: Edge) => (
           <Edge
             key={edge.id}
             edge={edge}
@@ -237,27 +245,25 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
             width={width}
             height={height}
             onlyRenderVisibleElements={onlyRenderVisibleElements}
-          />
-        ))}
-        {renderConnectionLine && (
-          <ConnectionLine
-            nodes={nodes}
-            connectionNodeId={connectionNodeId!}
-            connectionHandleId={connectionHandleId}
-            connectionHandleType={connectionHandleType!}
-            connectionPositionX={connectionPosition.x}
-            connectionPositionY={connectionPosition.y}
-            transform={transform}
-            connectionLineStyle={connectionLineStyle}
-            connectionLineType={connectionLineType}
-            connectionSourceOffsetX={connectionSourceOffsetX}
-            connectionSourceOffsetY={connectionSourceOffsetY}
-            isConnectable={nodesConnectable}
-            CustomConnectionLineComponent={connectionLineComponent}
-          />
-        )}
-      </g>
-    </svg>
+          />{renderConnectionLine && (
+            <ConnectionLine
+                nodes={nodes}
+                connectionNodeId={connectionNodeId!}
+                connectionHandleId={connectionHandleId}
+                connectionHandleType={connectionHandleType!}
+                connectionPositionX={connectionPosition.x}
+                connectionPositionY={connectionPosition.y}
+                transform={transform}
+                connectionLineStyle={connectionLineStyle}
+                connectionLineType={connectionLineType}
+                connectionSourceOffsetX={connectionSourceOffsetX}
+                connectionSourceOffsetY={connectionSourceOffsetY}
+                isConnectable={nodesConnectable}
+                CustomConnectionLineComponent={connectionLineComponent}
+              />
+            )}</g></svg>
+        )})}
+      </div>
   );
 };
 

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -223,47 +223,51 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   const transformStyle = `translate(${transform[0]},${transform[1]}) scale(${transform[2]})`;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
   //console.log({ state })
-  //const isParentedSceneSelected = 
+  //const isParentedSceneSelected =
   //const zIndex = (selected ? 10 : 3) + (10 * nestLevel)
 
   return (
     <div>
-        {edges.map((edge: Edge) => {
-          console.log({ iAmEdge: edge, edge, edgeProps: props});
-          return (
-            <svg width={width} height={height} className="react-flow__edges" style={{zIndex: 5}}>
-      <MarkerDefinitions color={arrowHeadColor} />
-      <g transform={transformStyle}>
-          <Edge
-            key={edge.id}
-            edge={edge}
-            props={props}
-            nodes={nodes}
-            selectedElements={selectedElements}
-            elementsSelectable={elementsSelectable}
-            transform={transform}
-            width={width}
-            height={height}
-            onlyRenderVisibleElements={onlyRenderVisibleElements}
-          />{renderConnectionLine && (
-            <ConnectionLine
+      {edges.map((edge: Edge) => {
+        console.log({ iAmEdge: edge, edge, edgeProps: props });
+        return (
+          <svg width={width} height={height} className="react-flow__edges" style={{ zIndex: 5 }}>
+            <MarkerDefinitions color={arrowHeadColor} />
+            <g transform={transformStyle}>
+              <Edge
+                key={edge.id}
+                edge={edge}
+                props={props}
                 nodes={nodes}
-                connectionNodeId={connectionNodeId!}
-                connectionHandleId={connectionHandleId}
-                connectionHandleType={connectionHandleType!}
-                connectionPositionX={connectionPosition.x}
-                connectionPositionY={connectionPosition.y}
+                selectedElements={selectedElements}
+                elementsSelectable={elementsSelectable}
                 transform={transform}
-                connectionLineStyle={connectionLineStyle}
-                connectionLineType={connectionLineType}
-                connectionSourceOffsetX={connectionSourceOffsetX}
-                connectionSourceOffsetY={connectionSourceOffsetY}
-                isConnectable={nodesConnectable}
-                CustomConnectionLineComponent={connectionLineComponent}
+                width={width}
+                height={height}
+                onlyRenderVisibleElements={onlyRenderVisibleElements}
               />
-            )}</g></svg>
-        )})}
-      </div>
+              {renderConnectionLine && (
+                <ConnectionLine
+                  nodes={nodes}
+                  connectionNodeId={connectionNodeId!}
+                  connectionHandleId={connectionHandleId}
+                  connectionHandleType={connectionHandleType!}
+                  connectionPositionX={connectionPosition.x}
+                  connectionPositionY={connectionPosition.y}
+                  transform={transform}
+                  connectionLineStyle={connectionLineStyle}
+                  connectionLineType={connectionLineType}
+                  connectionSourceOffsetX={connectionSourceOffsetX}
+                  connectionSourceOffsetY={connectionSourceOffsetY}
+                  isConnectable={nodesConnectable}
+                  CustomConnectionLineComponent={connectionLineComponent}
+                />
+              )}
+            </g>
+          </svg>
+        );
+      })}
+    </div>
   );
 };
 

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -229,21 +229,35 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   //const isParentedSceneSelected =
   //const zIndex = (selected ? 10 : 3) + (10 * nestLevel)
 
-  const sceneIdsPerEdgeConnection = (edgeTargetNodeId: string, edgeSourceNodeId: string): string[] => {
-    const edgeNodes = nodes.filter(n => n.id === edgeTargetNodeId || n.id === edgeSourceNodeId)
+  // const sceneIdsPerEdgeConnection = (edgeTargetNodeId: string, edgeSourceNodeId: string): string[] => {
+  //   const edgeNodes = nodes.filter(n => n.id === edgeTargetNodeId || n.id === edgeSourceNodeId)
 
-    let sceneIds = new Set() as Set<string>
-    for (const node of edgeNodes) {
-      if (node.parentId) {
-        sceneIds.add(node.parentId)
-      }
-    }
-    return Array.from(sceneIds)
-  }
+  //   let sceneIds = new Set() as Set<string>
+  //   for (const node of edgeNodes) {
+  //     if (node.parentId) {
+  //       sceneIds.add(node.parentId)
+  //     }
+  //   }
+  //   return Array.from(sceneIds)
+  // }
   const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined, edgeTargetNodeId: string, edgeSourceNodeId: string): number => {
     console.log({ mostRecentlyTouchedSceneIds, edgeSourceNodeId, edgeTargetNodeId})
     if (mostRecentlyTouchedSceneIds) {
-      
+
+      const parentIds = nodes.filter(n => n.id === edgeTargetNodeId || n.id === edgeSourceNodeId).map(n => n?.parentId)
+      // const relevantSceneNodeId = parentId || id; // if cannot find node parent, that means it's a scene, and this is the scene id;
+      //const isEdgeAtForefront = firstNodeSceneId === relevantSceneNodeId;
+      //const isSceneAndFirstNodeSceneId = type === "scene" && firstNodeSceneId === id;
+      const relevantSceneIdIndex = Math.min(...parentIds.map(parentId => mostRecentlyTouchedSceneIds.findIndex(sceneId => parentId === sceneId)));
+      const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => idx === -1 ? 0 : ary.length - idx;
+      //const sceneZIndex = (isEdgeAtForefront || isSceneAndFirstNodeSceneId ? 20 : 10) + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex); // nestLevel should be 1
+      const sceneZIndex = (10 + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex) * 10) + 5; // add +5 for nodes sitting on top of scenes
+      console.log("THIS IS INSIDE EDGE RENDERER")
+      console.log({ parentIds, relevantSceneIdIndex, sceneZIndex })
+      return sceneZIndex;
+
+
+      /** old 
       const firstNodeSceneId = mostRecentlyTouchedSceneIds[0];
       const isEdgeAtForefront = sceneIdsPerEdgeConnection(edgeTargetNodeId, edgeSourceNodeId).includes(firstNodeSceneId);
       const highestSceneIdPartOfEdge = sceneIdsPerEdgeConnection(edgeTargetNodeId, edgeSourceNodeId)[0];
@@ -252,6 +266,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
       const sceneZIndex = (isEdgeAtForefront ? 20 : 10) + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex); // nestLevel should be 1
 
       return sceneZIndex;
+      */
     }
     
     return 3;

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -62,7 +62,7 @@ const Edge = ({
   width,
   height,
   onlyRenderVisibleElements,
-  connectionMode,
+  connectionMode
 }: EdgeWrapperProps) => {
   const sourceHandleId = edge.sourceHandle || null;
   const targetHandleId = edge.targetHandle || null;
@@ -229,12 +229,35 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   //const isParentedSceneSelected =
   //const zIndex = (selected ? 10 : 3) + (10 * nestLevel)
 
+  const sceneIdsPerEdgeConnection = (edgeTargetNodeId: string, edgeSourceNodeId: string): string[] => {
+    const edgeNodes = nodes.filter(n => n.id === edgeTargetNodeId || n.id === edgeSourceNodeId)
+
+    let sceneIds = new Set() as Set<string>
+    for (const node of edgeNodes) {
+      if (node.parentId) {
+        sceneIds.add(node.parentId)
+      }
+    }
+    return Array.from(sceneIds)
+  }
+  const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined, edgeTargetNodeId: string, edgeSourceNodeId: string): number => {
+    console.log({ mostRecentlyTouchedSceneIds, edgeSourceNodeId, edgeTargetNodeId})
+    if (mostRecentlyTouchedSceneIds) {
+      const firstNodeSceneId = mostRecentlyTouchedSceneIds[0];
+      const isEdgeAtForefront = sceneIdsPerEdgeConnection(edgeTargetNodeId, edgeSourceNodeId).includes(firstNodeSceneId)
+
+      return isEdgeAtForefront ? 3 : 2
+    }
+    
+    return 2
+  }
+
   return (
     <div>
       {edges.map((edge: Edge) => {
         console.log({ iAmEdge: edge, edge, edgeProps: props });
         return (
-          <svg width={width} height={height} className="react-flow__edges" style={{ zIndex: 5 }}>
+          <svg width={width} height={height} className="react-flow__edges" style={{ zIndex: calculateZIndexes(props.mostRecentlyTouchedSceneIds, edge.target, edge.source) }}>
             <MarkerDefinitions color={arrowHeadColor} />
             <g transform={transformStyle}>
               <Edge

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -148,8 +148,6 @@ const Edge = ({
 
   const isSelected = selectedElements?.some((elm) => isEdge(elm) && elm.id === edge.id) || false;
 
-  console.log({ edgeStyle: edge.style });
-
   return (
     <EdgeComponent
       key={edge.id}
@@ -208,8 +206,6 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   const width = useStoreState((state) => state.width);
   const height = useStoreState((state) => state.height);
 
-  console.log({ mostrecentlysomethingggg: props.mostRecentlyTouchedSceneIds });
-
   const [connectionSourceOffsetX, connectionSourceOffsetY] = useMemo(
     () => (connectionNodeId ? getEdgeOffsets(nodes, connectionNodeId) : [0, 0]),
     [nodes, connectionNodeId]
@@ -230,8 +226,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   const renderConnectionLine = connectionNodeId && connectionHandleType;
 
   /**
-   * This is calculating z-index styles for an edge.
-   * This is calculating scene node z-indexes in increments of 10 (+ 5): 15, 25, 35, 45, etc.
+   * This is calculating z-index styles for an edge in increments of 10 (+ 5): 15, 25, 35, 45, etc.
    * The strategy is to find the highest possible z-index associated with this edge.
    * If you're drawing the edge, then it should have the highest z-index value of anything
    * in our node view.
@@ -282,8 +277,8 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
         return Math.min(...uniqueSceneIdsIndexedByMostRecentlyTouched);
       };
       // A lower `sceneIdIndex` means that that scene has been the more recently touched. So if we subtract that number from number of all
-      // scene nodes that have been touched and multiply it by 10, we'll get scene z-indexes sequenced in increments of 10.
-      // And give edges belonging to scene nodes that haven't been touched the lowest z-index.
+      // scene nodes that have been touched and multiply it by 10, we'll get edge z-indexes sequenced in increments of 10.
+      // And give edges belonging to scene nodes that haven't been touched the lowest z-index (though we actually wouldn't expect this to happen).
       const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => (idx === -1 ? 0 : (ary.length - idx) * 10);
 
       /**
@@ -300,6 +295,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
       return sceneZIndex;
     }
 
+    // Default z-index found in src/style.css
     return 3;
   };
 

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -164,7 +164,7 @@ const Edge = ({
       labelBgStyle={edge.labelBgStyle}
       labelBgPadding={edge.labelBgPadding}
       labelBgBorderRadius={edge.labelBgBorderRadius}
-      style={{...edge.style, zIndex: 10000000}}
+      style={edge.style}
       arrowHeadType={edge.arrowHeadType}
       source={edge.source}
       target={edge.target}
@@ -243,13 +243,18 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined, edgeTargetNodeId: string, edgeSourceNodeId: string): number => {
     console.log({ mostRecentlyTouchedSceneIds, edgeSourceNodeId, edgeTargetNodeId})
     if (mostRecentlyTouchedSceneIds) {
+      
       const firstNodeSceneId = mostRecentlyTouchedSceneIds[0];
-      const isEdgeAtForefront = sceneIdsPerEdgeConnection(edgeTargetNodeId, edgeSourceNodeId).includes(firstNodeSceneId)
+      const isEdgeAtForefront = sceneIdsPerEdgeConnection(edgeTargetNodeId, edgeSourceNodeId).includes(firstNodeSceneId);
+      const highestSceneIdPartOfEdge = sceneIdsPerEdgeConnection(edgeTargetNodeId, edgeSourceNodeId)[0];
+      const relevantSceneIdIndex = mostRecentlyTouchedSceneIds.findIndex(sceneId => sceneId === highestSceneIdPartOfEdge);
+      const translateSceneIdIndexToZIndex = (ary: string[], idx: number) => ary.length - idx;
+      const sceneZIndex = (isEdgeAtForefront ? 20 : 10) + translateSceneIdIndexToZIndex(mostRecentlyTouchedSceneIds, relevantSceneIdIndex); // nestLevel should be 1
 
-      return isEdgeAtForefront ? 3 : 2
+      return sceneZIndex;
     }
     
-    return 2
+    return 3;
   }
 
   return (

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -226,6 +226,10 @@ const BaseEdgeRenderer = (props: EdgeRendererProps) => {
   const renderConnectionLine = connectionNodeId && connectionHandleType;
 
   /**
+   * TODO: Ideally this would be using a nested level to determine a z-index, for cases
+   * where there may be more than 2 levels of nodes (not part of the product spec yet but
+   * could be in the future).
+   * 
    * This is calculating z-index styles for an edge in increments of 10 (+ 5): 15, 25, 35, 45, etc.
    * The strategy is to find the highest possible z-index associated with this edge.
    * If you're drawing the edge, then it should have the highest z-index value of anything

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -36,6 +36,7 @@ interface EdgeRendererProps {
   onEdgeMouseLeave?: (event: React.MouseEvent, edge: Edge) => void;
   onEdgeUpdateStart?: (event: React.MouseEvent, edge: Edge) => void;
   edgeUpdaterRadius?: number;
+  mostRecentlyTouchedSceneIds?: string[];
 }
 
 interface EdgeWrapperProps {
@@ -204,6 +205,8 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   const elementsSelectable = useStoreState((state) => state.elementsSelectable);
   const width = useStoreState((state) => state.width);
   const height = useStoreState((state) => state.height);
+
+  console.log({ mostrecentlysomethingggg: props.mostRecentlyTouchedSceneIds })
 
   const [connectionSourceOffsetX, connectionSourceOffsetY] = useMemo(() =>
       connectionNodeId ? getEdgeOffsets(nodes, connectionNodeId) : [0, 0]

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -240,7 +240,10 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   //   }
   //   return Array.from(sceneIds)
   // }
-  const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined, edgeTargetNodeId: string, edgeSourceNodeId: string): number => {
+  const calculateZIndexes = (mostRecentlyTouchedSceneIds: string[] | undefined, edgeTargetNodeId: string | null, edgeSourceNodeId: string | null, renderConnectionLine: boolean): number => {
+    if (renderConnectionLine && !(Boolean(edgeSourceNodeId) && Boolean(edgeTargetNodeId))) {
+      return 10000000;
+    }
     console.log({ mostRecentlyTouchedSceneIds, edgeSourceNodeId, edgeTargetNodeId})
     if (mostRecentlyTouchedSceneIds) {
 
@@ -283,14 +286,34 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
 
   return (
     <div>
+      {renderConnectionLine && <svg width={width} height={height} className="react-flow__edges" style={{ zIndex: calculateZIndexes(props.mostRecentlyTouchedSceneIds, null, connectionNodeId, Boolean(renderConnectionLine)) }}>
+          <MarkerDefinitions color={arrowHeadColor} />
+          <g>
+            <ConnectionLine
+              nodes={nodes}
+              connectionNodeId={connectionNodeId!}
+              connectionHandleId={connectionHandleId}
+              connectionHandleType={connectionHandleType!}
+              connectionPositionX={connectionPosition.x}
+              connectionPositionY={connectionPosition.y}
+              transform={transform}
+              connectionLineStyle={connectionLineStyle}
+              connectionLineType={connectionLineType}
+              connectionSourceOffsetX={connectionSourceOffsetX}
+              connectionSourceOffsetY={connectionSourceOffsetY}
+              isConnectable={nodesConnectable}
+              CustomConnectionLineComponent={connectionLineComponent}
+            />
+          </g>
+        </svg>}
       {edges.map((edge: Edge) => {
         console.log({ iAmEdge: edge, edge, edgeProps: props });
         return (
-          <svg width={width} height={height} className="react-flow__edges" style={{ zIndex: calculateZIndexes(props.mostRecentlyTouchedSceneIds, edge.target, edge.source) }}>
+          <svg key={edge.id} width={width} height={height} className="react-flow__edges" style={{ zIndex: calculateZIndexes(props.mostRecentlyTouchedSceneIds, edge.target, edge.source, Boolean(renderConnectionLine)) }}>
             <MarkerDefinitions color={arrowHeadColor} />
             <g>
               <Edge
-                key={edge.id}
+                key={`edge-${edge.id}`}
                 edge={edge}
                 props={props}
                 nodes={nodes}
@@ -301,23 +324,6 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
                 height={height}
                 onlyRenderVisibleElements={onlyRenderVisibleElements}
               />
-              {renderConnectionLine && (
-                <ConnectionLine
-                  nodes={nodes}
-                  connectionNodeId={connectionNodeId!}
-                  connectionHandleId={connectionHandleId}
-                  connectionHandleType={connectionHandleType!}
-                  connectionPositionX={connectionPosition.x}
-                  connectionPositionY={connectionPosition.y}
-                  transform={transform}
-                  connectionLineStyle={connectionLineStyle}
-                  connectionLineType={connectionLineType}
-                  connectionSourceOffsetX={connectionSourceOffsetX}
-                  connectionSourceOffsetY={connectionSourceOffsetY}
-                  isConnectable={nodesConnectable}
-                  CustomConnectionLineComponent={connectionLineComponent}
-                />
-              )}
             </g>
           </svg>
         );

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -18,7 +18,7 @@ import {
   OnEdgeUpdateFunc,
 } from '../../types';
 
-interface EdgeRendererProps {
+export interface EdgeRendererProps {
   edgeTypes: any;
   connectionLineType: ConnectionLineType;
   connectionLineStyle?: CSSProperties;
@@ -192,7 +192,7 @@ const Edge = ({
   );
 };
 
-const EdgeRenderer = (props: EdgeRendererProps) => {
+const BaseEdgeRenderer = (props: EdgeRendererProps) => {
   const transform = useStoreState((state) => state.transform);
   const nodes = useStoreState((state) => state.nodes);
   const edges = useStoreState((state) => state.edges);
@@ -372,6 +372,6 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
   );
 };
 
-EdgeRenderer.displayName = 'EdgeRenderer';
+BaseEdgeRenderer.displayName = 'EdgeRenderer';
 
-export default memo(EdgeRenderer);
+export const EdgeRenderer = memo(BaseEdgeRenderer);

--- a/src/container/EdgeRenderer/index.tsx
+++ b/src/container/EdgeRenderer/index.tsx
@@ -223,7 +223,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
     connectionLineComponent,
     onlyRenderVisibleElements,
   } = props;
-  const transformStyle = `translate(${transform[0]},${transform[1]}) scale(${transform[2]})`;
+  // const transformStyle = `translate(${transform[0]},${transform[1]}) scale(${transform[2]})`;
   const renderConnectionLine = connectionNodeId && connectionHandleType;
   //console.log({ state })
   //const isParentedSceneSelected =
@@ -288,7 +288,7 @@ const EdgeRenderer = (props: EdgeRendererProps) => {
         return (
           <svg width={width} height={height} className="react-flow__edges" style={{ zIndex: calculateZIndexes(props.mostRecentlyTouchedSceneIds, edge.target, edge.source) }}>
             <MarkerDefinitions color={arrowHeadColor} />
-            <g transform={transformStyle}>
+            <g>
               <Edge
                 key={edge.id}
                 edge={edge}

--- a/src/container/FlowRenderer/index.tsx
+++ b/src/container/FlowRenderer/index.tsx
@@ -53,6 +53,7 @@ const FlowRenderer = ({
   onSelectionDrag,
   onSelectionDragStop,
   onSelectionContextMenu,
+  mostRecentlyTouchedSceneIds
 }: FlowRendererProps) => {
   const unsetNodesSelection = useStoreActions((actions) => actions.unsetNodesSelection);
   const resetSelectedElements = useStoreActions((actions) => actions.resetSelectedElements);
@@ -112,6 +113,7 @@ const FlowRenderer = ({
           onSelectionDrag={onSelectionDrag}
           onSelectionDragStop={onSelectionDragStop}
           onSelectionContextMenu={onSelectionContextMenu}
+          mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
         />
       )}
       <div className="react-flow__pane" onClick={onClick} onContextMenu={onContextMenu} onWheel={onWheel} />

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -29,6 +29,7 @@ export interface GraphViewProps extends Omit<ReactFlowProps, 'onSelectionChange'
 
 const GraphView = ({
   nodeTypes,
+  mostRecentlyTouchedSceneIds,
   edgeTypes,
   onMove,
   onMoveStart,
@@ -278,6 +279,7 @@ const GraphView = ({
         onEdgeMouseLeave={onEdgeMouseLeave}
         onEdgeUpdateStart={onEdgeUpdateStart}
         edgeUpdaterRadius={edgeUpdaterRadius}
+        mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
       />
     </FlowRenderer>
   );

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -244,6 +244,7 @@ const GraphView = ({
       onSelectionDrag={onSelectionDrag}
       onSelectionDragStop={onSelectionDragStop}
       onSelectionContextMenu={onSelectionContextMenu}
+      mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
     >
       <NodeRenderer
         nodeTypes={nodeTypes}
@@ -260,6 +261,7 @@ const GraphView = ({
         snapToGrid={snapToGrid}
         snapGrid={snapGrid}
         onlyRenderVisibleElements={onlyRenderVisibleElements}
+        mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
       />
       <EdgeRenderer
         edgeTypes={edgeTypes}

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef, memo } from 'react';
 import { useStoreActions, useStore } from '../../store/hooks';
 import FlowRenderer from '../FlowRenderer';
 import NodeRenderer from '../NodeRenderer';
-// import EdgeRenderer from '../EdgeRenderer';
 import { onLoadProject, onLoadGetElements, onLoadToObject } from '../../utils/graph';
 import useZoomPanHelper from '../../hooks/useZoomPanHelper';
 

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, memo } from 'react';
 import { useStoreActions, useStore } from '../../store/hooks';
 import FlowRenderer from '../FlowRenderer';
 import NodeRenderer from '../NodeRenderer';
-import EdgeRenderer from '../EdgeRenderer';
+// import EdgeRenderer from '../EdgeRenderer';
 import { onLoadProject, onLoadGetElements, onLoadToObject } from '../../utils/graph';
 import useZoomPanHelper from '../../hooks/useZoomPanHelper';
 
@@ -216,6 +216,27 @@ const GraphView = ({
     }
   }, [connectionMode]);
 
+  const edgeProps = {
+    edgeTypes,
+    onElementClick,
+    onEdgeDoubleClick,
+    connectionLineType,
+    connectionLineStyle,
+    connectionLineComponent,
+    connectionMode,
+    arrowHeadColor,
+    markerEndId,
+    onEdgeUpdate,
+    onlyRenderVisibleElements,
+    onEdgeContextMenu,
+    onEdgeMouseEnter,
+    onEdgeMouseMove,
+    onEdgeMouseLeave,
+    onEdgeUpdateStart,
+    edgeUpdaterRadius,
+    mostRecentlyTouchedSceneIds
+  }
+
   return (
     <FlowRenderer
       onPaneClick={onPaneClick}
@@ -262,8 +283,9 @@ const GraphView = ({
         snapGrid={snapGrid}
         onlyRenderVisibleElements={onlyRenderVisibleElements}
         mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
+        edgeProps={edgeProps}
       />
-      <EdgeRenderer
+      {/*<EdgeRenderer
         edgeTypes={edgeTypes}
         onElementClick={onElementClick}
         onEdgeDoubleClick={onEdgeDoubleClick}
@@ -282,7 +304,7 @@ const GraphView = ({
         onEdgeUpdateStart={onEdgeUpdateStart}
         edgeUpdaterRadius={edgeUpdaterRadius}
         mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
-      />
+      />*/}
     </FlowRenderer>
   );
 };

--- a/src/container/GraphView/index.tsx
+++ b/src/container/GraphView/index.tsx
@@ -216,7 +216,7 @@ const GraphView = ({
     }
   }, [connectionMode]);
 
-  const edgeProps = {
+  const edgeRendererProps = {
     edgeTypes,
     onElementClick,
     onEdgeDoubleClick,
@@ -267,6 +267,9 @@ const GraphView = ({
       onSelectionContextMenu={onSelectionContextMenu}
       mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
     >
+      {/**
+       * Per our modifications to this library, NodeRenderer renders edges, too (which is the EdgeRenderer)
+       */}
       <NodeRenderer
         nodeTypes={nodeTypes}
         onElementClick={onElementClick}
@@ -283,28 +286,8 @@ const GraphView = ({
         snapGrid={snapGrid}
         onlyRenderVisibleElements={onlyRenderVisibleElements}
         mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
-        edgeProps={edgeProps}
+        edgeRendererProps={edgeRendererProps}
       />
-      {/*<EdgeRenderer
-        edgeTypes={edgeTypes}
-        onElementClick={onElementClick}
-        onEdgeDoubleClick={onEdgeDoubleClick}
-        connectionLineType={connectionLineType}
-        connectionLineStyle={connectionLineStyle}
-        connectionLineComponent={connectionLineComponent}
-        connectionMode={connectionMode}
-        arrowHeadColor={arrowHeadColor}
-        markerEndId={markerEndId}
-        onEdgeUpdate={onEdgeUpdate}
-        onlyRenderVisibleElements={onlyRenderVisibleElements}
-        onEdgeContextMenu={onEdgeContextMenu}
-        onEdgeMouseEnter={onEdgeMouseEnter}
-        onEdgeMouseMove={onEdgeMouseMove}
-        onEdgeMouseLeave={onEdgeMouseLeave}
-        onEdgeUpdateStart={onEdgeUpdateStart}
-        edgeUpdaterRadius={edgeUpdaterRadius}
-        mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
-      />*/}
     </FlowRenderer>
   );
 };

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -101,7 +101,6 @@ const NodeRenderer = (props: NodeRendererProps) => {
     const children = visibleNodes.filter(n => n.parentId === node.id);
 
     return (
-      
       <NodeComponent
         key={node.id}
         id={node.id}
@@ -134,7 +133,6 @@ const NodeRenderer = (props: NodeRendererProps) => {
         isSelectable={isSelectable}
         isConnectable={isConnectable}
         resizeObserver={resizeObserver}
-        nestLevel={nestLevel}
         mostRecentlyTouchedSceneIds={props.mostRecentlyTouchedSceneIds}
       >
         <div style={{ position: 'relative' }}>
@@ -144,35 +142,30 @@ const NodeRenderer = (props: NodeRendererProps) => {
     );
   };
 
-  // const other = {...transformStyle, zIndex: 3, transformOrigin: "0 0", position: 'absolute'}
-
-
   return (
-      
     <div className="react-flow__nodes" style={transformStyle}>   
-        {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
-        <EdgeRenderer
-          edgeTypes={props.edgeProps.edgeTypes}
-          onElementClick={props.edgeProps.onElementClick}
-          onEdgeDoubleClick={props.edgeProps.onEdgeDoubleClick}
-          connectionLineType={props.edgeProps.connectionLineType}
-          connectionLineStyle={props.edgeProps.connectionLineStyle}
-          connectionLineComponent={props.edgeProps.connectionLineComponent}
-          connectionMode={props.edgeProps.connectionMode}
-          arrowHeadColor={props.edgeProps.arrowHeadColor}
-          markerEndId={props.edgeProps.markerEndId}
-          onEdgeUpdate={props.edgeProps.onEdgeUpdate}
-          onlyRenderVisibleElements={props.edgeProps.onlyRenderVisibleElements}
-          onEdgeContextMenu={props.edgeProps.onEdgeContextMenu}
-          onEdgeMouseEnter={props.edgeProps.onEdgeMouseEnter}
-          onEdgeMouseMove={props.edgeProps.onEdgeMouseMove}
-          onEdgeMouseLeave={props.edgeProps.onEdgeMouseLeave}
-          onEdgeUpdateStart={props.edgeProps.onEdgeUpdateStart}
-          edgeUpdaterRadius={props.edgeProps.edgeUpdaterRadius}
-          mostRecentlyTouchedSceneIds={props.edgeProps.mostRecentlyTouchedSceneIds}
-        />
-      </div>
-      
+      {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
+      <EdgeRenderer
+        edgeTypes={props.edgeProps.edgeTypes}
+        onElementClick={props.edgeProps.onElementClick}
+        onEdgeDoubleClick={props.edgeProps.onEdgeDoubleClick}
+        connectionLineType={props.edgeProps.connectionLineType}
+        connectionLineStyle={props.edgeProps.connectionLineStyle}
+        connectionLineComponent={props.edgeProps.connectionLineComponent}
+        connectionMode={props.edgeProps.connectionMode}
+        arrowHeadColor={props.edgeProps.arrowHeadColor}
+        markerEndId={props.edgeProps.markerEndId}
+        onEdgeUpdate={props.edgeProps.onEdgeUpdate}
+        onlyRenderVisibleElements={props.edgeProps.onlyRenderVisibleElements}
+        onEdgeContextMenu={props.edgeProps.onEdgeContextMenu}
+        onEdgeMouseEnter={props.edgeProps.onEdgeMouseEnter}
+        onEdgeMouseMove={props.edgeProps.onEdgeMouseMove}
+        onEdgeMouseLeave={props.edgeProps.onEdgeMouseLeave}
+        onEdgeUpdateStart={props.edgeProps.onEdgeUpdateStart}
+        edgeUpdaterRadius={props.edgeProps.edgeUpdaterRadius}
+        mostRecentlyTouchedSceneIds={props.edgeProps.mostRecentlyTouchedSceneIds}
+      />
+    </div>
   );
 };
 

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -2,12 +2,16 @@ import React, { memo, useMemo, ComponentType, MouseEvent, CSSProperties } from '
 
 import { getNodesInside } from '../../utils/graph';
 import { useStoreState, useStoreActions } from '../../store/hooks';
-import { Node, NodeTypesType, WrapNodeProps, Edge,
+import {
+  Node,
+  NodeTypesType,
+  WrapNodeProps,
+  Edge,
   ConnectionLineType,
   ConnectionLineComponent,
   ConnectionMode,
-  OnEdgeUpdateFunc
- } from '../../types';
+  OnEdgeUpdateFunc,
+} from '../../types';
 import EdgeRenderer from '../EdgeRenderer/index';
 
 interface EdgeRendererProps {
@@ -98,7 +102,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
     const isSelectable = node.selectable || (elementsSelectable && typeof node.selectable === 'undefined');
     const isConnectable = node.connectable || (nodesConnectable && typeof node.connectable === 'undefined');
 
-    const children = visibleNodes.filter(n => n.parentId === node.id);
+    const children = visibleNodes.filter((n) => n.parentId === node.id);
 
     return (
       <NodeComponent
@@ -135,16 +139,14 @@ const NodeRenderer = (props: NodeRendererProps) => {
         resizeObserver={resizeObserver}
         mostRecentlyTouchedSceneIds={props.mostRecentlyTouchedSceneIds}
       >
-        <div style={{ position: 'relative' }}>
-          {children.map(child => renderNode(child, nestLevel + 1))}
-        </div>
+        <div style={{ position: 'relative' }}>{children.map((child) => renderNode(child, nestLevel + 1))}</div>
       </NodeComponent>
     );
   };
 
   return (
-    <div className="react-flow__nodes" style={transformStyle}>   
-      {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
+    <div className="react-flow__nodes" style={transformStyle}>
+      {visibleNodes.filter((node) => !node.parentId).map((node) => renderNode(node, 0))}
       <EdgeRenderer {...props.edgeRendererProps} />
     </div>
   );

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -47,7 +47,7 @@ interface NodeRendererProps {
   snapGrid: [number, number];
   onlyRenderVisibleElements: boolean;
   mostRecentlyTouchedSceneIds?: string[];
-  edgeProps: EdgeRendererProps;
+  edgeRendererProps: EdgeRendererProps;
 }
 
 const NodeRenderer = (props: NodeRendererProps) => {
@@ -145,26 +145,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
   return (
     <div className="react-flow__nodes" style={transformStyle}>   
       {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
-      <EdgeRenderer
-        edgeTypes={props.edgeProps.edgeTypes}
-        onElementClick={props.edgeProps.onElementClick}
-        onEdgeDoubleClick={props.edgeProps.onEdgeDoubleClick}
-        connectionLineType={props.edgeProps.connectionLineType}
-        connectionLineStyle={props.edgeProps.connectionLineStyle}
-        connectionLineComponent={props.edgeProps.connectionLineComponent}
-        connectionMode={props.edgeProps.connectionMode}
-        arrowHeadColor={props.edgeProps.arrowHeadColor}
-        markerEndId={props.edgeProps.markerEndId}
-        onEdgeUpdate={props.edgeProps.onEdgeUpdate}
-        onlyRenderVisibleElements={props.edgeProps.onlyRenderVisibleElements}
-        onEdgeContextMenu={props.edgeProps.onEdgeContextMenu}
-        onEdgeMouseEnter={props.edgeProps.onEdgeMouseEnter}
-        onEdgeMouseMove={props.edgeProps.onEdgeMouseMove}
-        onEdgeMouseLeave={props.edgeProps.onEdgeMouseLeave}
-        onEdgeUpdateStart={props.edgeProps.onEdgeUpdateStart}
-        edgeUpdaterRadius={props.edgeProps.edgeUpdaterRadius}
-        mostRecentlyTouchedSceneIds={props.edgeProps.mostRecentlyTouchedSceneIds}
-      />
+      <EdgeRenderer {...props.edgeRendererProps} />
     </div>
   );
 };

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -148,29 +148,31 @@ const NodeRenderer = (props: NodeRendererProps) => {
 
 
   return (
+      
     <div className="react-flow__nodes" style={transformStyle}>   
-      {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
-      <EdgeRenderer
-        edgeTypes={props.edgeProps.edgeTypes}
-        onElementClick={props.edgeProps.onElementClick}
-        onEdgeDoubleClick={props.edgeProps.onEdgeDoubleClick}
-        connectionLineType={props.edgeProps.connectionLineType}
-        connectionLineStyle={props.edgeProps.connectionLineStyle}
-        connectionLineComponent={props.edgeProps.connectionLineComponent}
-        connectionMode={props.edgeProps.connectionMode}
-        arrowHeadColor={props.edgeProps.arrowHeadColor}
-        markerEndId={props.edgeProps.markerEndId}
-        onEdgeUpdate={props.edgeProps.onEdgeUpdate}
-        onlyRenderVisibleElements={props.edgeProps.onlyRenderVisibleElements}
-        onEdgeContextMenu={props.edgeProps.onEdgeContextMenu}
-        onEdgeMouseEnter={props.edgeProps.onEdgeMouseEnter}
-        onEdgeMouseMove={props.edgeProps.onEdgeMouseMove}
-        onEdgeMouseLeave={props.edgeProps.onEdgeMouseLeave}
-        onEdgeUpdateStart={props.edgeProps.onEdgeUpdateStart}
-        edgeUpdaterRadius={props.edgeProps.edgeUpdaterRadius}
-        mostRecentlyTouchedSceneIds={props.edgeProps.mostRecentlyTouchedSceneIds}
-      />
-    </div>
+        {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
+        <EdgeRenderer
+          edgeTypes={props.edgeProps.edgeTypes}
+          onElementClick={props.edgeProps.onElementClick}
+          onEdgeDoubleClick={props.edgeProps.onEdgeDoubleClick}
+          connectionLineType={props.edgeProps.connectionLineType}
+          connectionLineStyle={props.edgeProps.connectionLineStyle}
+          connectionLineComponent={props.edgeProps.connectionLineComponent}
+          connectionMode={props.edgeProps.connectionMode}
+          arrowHeadColor={props.edgeProps.arrowHeadColor}
+          markerEndId={props.edgeProps.markerEndId}
+          onEdgeUpdate={props.edgeProps.onEdgeUpdate}
+          onlyRenderVisibleElements={props.edgeProps.onlyRenderVisibleElements}
+          onEdgeContextMenu={props.edgeProps.onEdgeContextMenu}
+          onEdgeMouseEnter={props.edgeProps.onEdgeMouseEnter}
+          onEdgeMouseMove={props.edgeProps.onEdgeMouseMove}
+          onEdgeMouseLeave={props.edgeProps.onEdgeMouseLeave}
+          onEdgeUpdateStart={props.edgeProps.onEdgeUpdateStart}
+          edgeUpdaterRadius={props.edgeProps.edgeUpdaterRadius}
+          mostRecentlyTouchedSceneIds={props.edgeProps.mostRecentlyTouchedSceneIds}
+        />
+      </div>
+      
   );
 };
 

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -2,12 +2,7 @@ import React, { memo, useMemo, ComponentType, MouseEvent } from 'react';
 
 import { getNodesInside } from '../../utils/graph';
 import { useStoreState, useStoreActions } from '../../store/hooks';
-import {
-  Node,
-  NodeTypesType,
-  WrapNodeProps,
-  Edge,
-} from '../../types';
+import { Node, NodeTypesType, WrapNodeProps, Edge } from '../../types';
 import { EdgeRenderer, EdgeRendererProps } from '../EdgeRenderer/index';
 
 interface NodeRendererProps {
@@ -39,16 +34,17 @@ const NodeRenderer = (props: NodeRendererProps) => {
   const height = useStoreState((state) => state.height);
   const nodes = useStoreState((state) => state.nodes);
   const updateNodeDimensions = useStoreActions((actions) => actions.updateNodeDimensions);
+
+  const visibleNodes = props.onlyRenderVisibleElements
+    ? getNodesInside(nodes, { x: 0, y: 0, width, height }, transform, true)
+    : nodes;
+
   const transformStyle = useMemo(
     () => ({
       transform: `translate(${transform[0]}px,${transform[1]}px) scale(${transform[2]})`,
     }),
     [transform[0], transform[1], transform[2]]
   );
-
-  const visibleNodes = props.onlyRenderVisibleElements
-    ? getNodesInside(nodes, { x: 0, y: 0, width, height }, transform, true)
-    : nodes;
 
   const resizeObserver = useMemo(() => {
     if (typeof ResizeObserver === 'undefined') {

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -1,8 +1,36 @@
-import React, { memo, useMemo, ComponentType, MouseEvent } from 'react';
+import React, { memo, useMemo, ComponentType, MouseEvent, CSSProperties } from 'react';
 
 import { getNodesInside } from '../../utils/graph';
 import { useStoreState, useStoreActions } from '../../store/hooks';
-import { Node, NodeTypesType, WrapNodeProps, Edge } from '../../types';
+import { Node, NodeTypesType, WrapNodeProps, Edge,
+  ConnectionLineType,
+  ConnectionLineComponent,
+  ConnectionMode,
+  OnEdgeUpdateFunc
+ } from '../../types';
+import EdgeRenderer from '../EdgeRenderer/index';
+
+interface EdgeRendererProps {
+  edgeTypes: any;
+  connectionLineType: ConnectionLineType;
+  connectionLineStyle?: CSSProperties;
+  connectionLineComponent?: ConnectionLineComponent;
+  connectionMode?: ConnectionMode;
+  onElementClick?: (event: React.MouseEvent, element: Node | Edge) => void;
+  onEdgeDoubleClick?: (event: React.MouseEvent, edge: Edge) => void;
+  arrowHeadColor: string;
+  markerEndId?: string;
+  onlyRenderVisibleElements: boolean;
+  onEdgeUpdate?: OnEdgeUpdateFunc;
+  onEdgeContextMenu?: (event: React.MouseEvent, edge: Edge) => void;
+  onEdgeMouseEnter?: (event: React.MouseEvent, edge: Edge) => void;
+  onEdgeMouseMove?: (event: React.MouseEvent, edge: Edge) => void;
+  onEdgeMouseLeave?: (event: React.MouseEvent, edge: Edge) => void;
+  onEdgeUpdateStart?: (event: React.MouseEvent, edge: Edge) => void;
+  edgeUpdaterRadius?: number;
+  mostRecentlyTouchedSceneIds?: string[];
+}
+
 interface NodeRendererProps {
   nodeTypes: NodeTypesType;
   selectNodesOnDrag: boolean;
@@ -19,6 +47,7 @@ interface NodeRendererProps {
   snapGrid: [number, number];
   onlyRenderVisibleElements: boolean;
   mostRecentlyTouchedSceneIds?: string[];
+  edgeProps: EdgeRendererProps;
 }
 
 const NodeRenderer = (props: NodeRendererProps) => {
@@ -31,6 +60,12 @@ const NodeRenderer = (props: NodeRendererProps) => {
   const height = useStoreState((state) => state.height);
   const nodes = useStoreState((state) => state.nodes);
   const updateNodeDimensions = useStoreActions((actions) => actions.updateNodeDimensions);
+  const transformStyle = useMemo(
+    () => ({
+      transform: `translate(${transform[0]}px,${transform[1]}px) scale(${transform[2]})`,
+    }),
+    [transform[0], transform[1], transform[2]]
+  );
 
   const visibleNodes = props.onlyRenderVisibleElements
     ? getNodesInside(nodes, { x: 0, y: 0, width, height }, transform, true)
@@ -109,9 +144,32 @@ const NodeRenderer = (props: NodeRendererProps) => {
     );
   };
 
+  // const other = {...transformStyle, zIndex: 3, transformOrigin: "0 0", position: 'absolute'}
+
+
   return (
-    <div className="react-flow__nodes">
+    <div className="react-flow__nodes" style={transformStyle}>   
       {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
+      <EdgeRenderer
+        edgeTypes={props.edgeProps.edgeTypes}
+        onElementClick={props.edgeProps.onElementClick}
+        onEdgeDoubleClick={props.edgeProps.onEdgeDoubleClick}
+        connectionLineType={props.edgeProps.connectionLineType}
+        connectionLineStyle={props.edgeProps.connectionLineStyle}
+        connectionLineComponent={props.edgeProps.connectionLineComponent}
+        connectionMode={props.edgeProps.connectionMode}
+        arrowHeadColor={props.edgeProps.arrowHeadColor}
+        markerEndId={props.edgeProps.markerEndId}
+        onEdgeUpdate={props.edgeProps.onEdgeUpdate}
+        onlyRenderVisibleElements={props.edgeProps.onlyRenderVisibleElements}
+        onEdgeContextMenu={props.edgeProps.onEdgeContextMenu}
+        onEdgeMouseEnter={props.edgeProps.onEdgeMouseEnter}
+        onEdgeMouseMove={props.edgeProps.onEdgeMouseMove}
+        onEdgeMouseLeave={props.edgeProps.onEdgeMouseLeave}
+        onEdgeUpdateStart={props.edgeProps.onEdgeUpdateStart}
+        edgeUpdaterRadius={props.edgeProps.edgeUpdaterRadius}
+        mostRecentlyTouchedSceneIds={props.edgeProps.mostRecentlyTouchedSceneIds}
+      />
     </div>
   );
 };

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, ComponentType, MouseEvent, CSSProperties } from 'react';
+import React, { memo, useMemo, ComponentType, MouseEvent } from 'react';
 
 import { getNodesInside } from '../../utils/graph';
 import { useStoreState, useStoreActions } from '../../store/hooks';
@@ -7,33 +7,8 @@ import {
   NodeTypesType,
   WrapNodeProps,
   Edge,
-  ConnectionLineType,
-  ConnectionLineComponent,
-  ConnectionMode,
-  OnEdgeUpdateFunc,
 } from '../../types';
-import EdgeRenderer from '../EdgeRenderer/index';
-
-interface EdgeRendererProps {
-  edgeTypes: any;
-  connectionLineType: ConnectionLineType;
-  connectionLineStyle?: CSSProperties;
-  connectionLineComponent?: ConnectionLineComponent;
-  connectionMode?: ConnectionMode;
-  onElementClick?: (event: React.MouseEvent, element: Node | Edge) => void;
-  onEdgeDoubleClick?: (event: React.MouseEvent, edge: Edge) => void;
-  arrowHeadColor: string;
-  markerEndId?: string;
-  onlyRenderVisibleElements: boolean;
-  onEdgeUpdate?: OnEdgeUpdateFunc;
-  onEdgeContextMenu?: (event: React.MouseEvent, edge: Edge) => void;
-  onEdgeMouseEnter?: (event: React.MouseEvent, edge: Edge) => void;
-  onEdgeMouseMove?: (event: React.MouseEvent, edge: Edge) => void;
-  onEdgeMouseLeave?: (event: React.MouseEvent, edge: Edge) => void;
-  onEdgeUpdateStart?: (event: React.MouseEvent, edge: Edge) => void;
-  edgeUpdaterRadius?: number;
-  mostRecentlyTouchedSceneIds?: string[];
-}
+import { EdgeRenderer, EdgeRendererProps } from '../EdgeRenderer/index';
 
 interface NodeRendererProps {
   nodeTypes: NodeTypesType;

--- a/src/container/NodeRenderer/index.tsx
+++ b/src/container/NodeRenderer/index.tsx
@@ -18,6 +18,7 @@ interface NodeRendererProps {
   snapToGrid: boolean;
   snapGrid: [number, number];
   onlyRenderVisibleElements: boolean;
+  mostRecentlyTouchedSceneIds?: string[];
 }
 
 const NodeRenderer = (props: NodeRendererProps) => {
@@ -34,13 +35,6 @@ const NodeRenderer = (props: NodeRendererProps) => {
   const visibleNodes = props.onlyRenderVisibleElements
     ? getNodesInside(nodes, { x: 0, y: 0, width, height }, transform, true)
     : nodes;
-
-  const transformStyle = useMemo(
-    () => ({
-      transform: `translate(${transform[0]}px,${transform[1]}px) scale(${transform[2]})`,
-    }),
-    [transform[0], transform[1], transform[2]]
-  );
 
   const resizeObserver = useMemo(() => {
     if (typeof ResizeObserver === 'undefined') {
@@ -72,6 +66,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
     const children = visibleNodes.filter(n => n.parentId === node.id);
 
     return (
+      
       <NodeComponent
         key={node.id}
         id={node.id}
@@ -105,6 +100,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
         isConnectable={isConnectable}
         resizeObserver={resizeObserver}
         nestLevel={nestLevel}
+        mostRecentlyTouchedSceneIds={props.mostRecentlyTouchedSceneIds}
       >
         <div style={{ position: 'relative' }}>
           {children.map(child => renderNode(child, nestLevel + 1))}
@@ -114,7 +110,7 @@ const NodeRenderer = (props: NodeRendererProps) => {
   };
 
   return (
-    <div className="react-flow__nodes" style={transformStyle}>
+    <div className="react-flow__nodes">
       {visibleNodes.filter(node => !node.parentId).map(node => renderNode(node, 0))}
     </div>
   );

--- a/src/container/ReactFlow/index.tsx
+++ b/src/container/ReactFlow/index.tsx
@@ -119,6 +119,7 @@ export interface ReactFlowProps extends Omit<HTMLAttributes<HTMLDivElement>, 'on
   edgeUpdaterRadius?: number;
   nodeTypesId?: string;
   edgeTypesId?: string;
+  mostRecentlyTouchedSceneIds?: string[];
 }
 
 export type ReactFlowRefType = HTMLDivElement;
@@ -127,6 +128,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
   (
     {
       elements = [],
+      mostRecentlyTouchedSceneIds = [],
       className,
       nodeTypes = defaultNodeTypes,
       edgeTypes = defaultEdgeTypes,
@@ -274,6 +276,7 @@ const ReactFlow = forwardRef<ReactFlowRefType, ReactFlowProps>(
             onEdgeMouseLeave={onEdgeMouseLeave}
             onEdgeUpdateStart={onEdgeUpdateStart}
             edgeUpdaterRadius={edgeUpdaterRadius}
+            mostRecentlyTouchedSceneIds={mostRecentlyTouchedSceneIds}
           />
           <ElementUpdater elements={elements} />
           {onSelectionChange && <SelectionListener onSelectionChange={onSelectionChange} />}

--- a/src/style.css
+++ b/src/style.css
@@ -38,7 +38,7 @@
   top: 0;
   left: 0;
   pointer-events: none;
-  z-index: 3;
+  z-index: 4;
 }
 
 .react-flow__edge {
@@ -86,12 +86,16 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  transform-origin: 0 0;
   z-index: 3;
+  transform-origin: 0 0;
   /*position: absolute;
   width: 100%;
   height: 100%;
   pointer-events: none;*/ /* /*  /*5 gets this somewhat working*/
+}
+
+.react-flow__nodes-transform {
+  transform-origin: 0 0;
 }
 
 .react-flow__node {

--- a/src/style.css
+++ b/src/style.css
@@ -86,16 +86,8 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+  transform-origin: 0 0;
   z-index: 3;
-  transform-origin: 0 0;
-  /*position: absolute;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;*/ /* /*  /*5 gets this somewhat working*/
-}
-
-.react-flow__nodes-transform {
-  transform-origin: 0 0;
 }
 
 .react-flow__node {

--- a/src/style.css
+++ b/src/style.css
@@ -38,7 +38,7 @@
   top: 0;
   left: 0;
   pointer-events: none;
-  z-index: 4;
+  z-index: 3;
 }
 
 .react-flow__edge {
@@ -86,7 +86,12 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  transform-origin: 0 0; /* z-index: 3; /*5 gets this somewhat working*/
+  transform-origin: 0 0;
+  z-index: 3;
+  /*position: absolute;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;*/ /* /*  /*5 gets this somewhat working*/
 }
 
 .react-flow__node {

--- a/src/style.css
+++ b/src/style.css
@@ -86,8 +86,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  transform-origin: 0 0;
-  z-index: 3;
+  transform-origin: 0 0; /* z-index: 3; /*5 gets this somewhat working*/
 }
 
 .react-flow__node {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -244,6 +244,7 @@ export interface WrapNodeProps<T = any> {
   isDragging?: boolean;
   resizeObserver: ResizeObserver | null;
   nestLevel: number;
+  mostRecentlyTouchedSceneIds?: string[];
 }
 
 export type FitViewParams = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -243,7 +243,6 @@ export interface WrapNodeProps<T = any> {
   snapGrid?: SnapGrid;
   isDragging?: boolean;
   resizeObserver: ResizeObserver | null;
-  nestLevel: number;
   mostRecentlyTouchedSceneIds?: string[];
 }
 


### PR DESCRIPTION
### What

- [x] Based on the history of what scene you've most recently touched:
  - [x] Calculate z-indexes for overlay nodes and scene nodes
  - [x] Use slightly different logic to calculate z-indexes for connecting edges (find the most recently touched scene that's connected to an edge)
- [x] Move EdgeRenderer inside NodeRenderer 👉 this had to happen in order to get a nice interleaving effect of z-indexes (otherwise edges are above everything, or below everything)
- [x] Separate edge svgs so we can apply different z-indexes to all edges (before all <g>path components were nested inside a single <svg> component)
- [x] Scene z-indexes are incremented by 10; overlay nodes and edges are incremented by an additional 5:
![IMG-6410](https://user-images.githubusercontent.com/4974740/125127342-394b4700-e0b1-11eb-9951-ee98a048d91c.jpg)

### Why

Right now edges sit on top of all nodes, which is visually confusing when scenes overlap (see demos below)

Ticket: https://dev.azure.com/strivr/Products/_workitems/edit/33624/


### See :eyes:

#### Before

![z-index-before](https://user-images.githubusercontent.com/4974740/125126354-d4dbb800-e0af-11eb-966b-36dd5ac7c035.gif)

#### After

![z-index-1](https://user-images.githubusercontent.com/4974740/125126312-bf668e00-e0af-11eb-8c54-a158bd44fb23.gif)
![z-index-2](https://user-images.githubusercontent.com/4974740/125126316-c097bb00-e0af-11eb-8424-f69b8b142e28.gif)
![z-index-3](https://user-images.githubusercontent.com/4974740/125128470-ee323380-e0b2-11eb-9faf-cbe21a652422.gif)

### Related PRs

https://dev.azure.com/strivr/Products/_git/strivr-creator-v3/pullrequest/11163