### PR TITLE
Disable mouse events on node being dragged

### DIFF
--- a/src/components/Nodes/wrapNode.tsx
+++ b/src/components/Nodes/wrapNode.tsx
@@ -132,7 +132,7 @@ export default (NodeComponent: ComponentType<NodeComponentProps>) => {
         zIndex: calculatedZIndexValue,
         transform: `translate(${xPos}px,${yPos}px)`,
         pointerEvents:
-        isSelectable || isDraggable || onClick || onMouseEnter || onMouseMove || onMouseLeave ? 'all' : 'none',
+        !isDragging && (isSelectable || isDraggable || onClick || onMouseEnter || onMouseMove || onMouseLeave) ? 'all' : 'none',
         // prevents jumping of nodes on start
         opacity: isInitialized ? 1 : 0,
         ...style,


### PR DESCRIPTION
So for the new drag drop approach, we disable mouse events on any node being dragged. This will allow us to read events on nodes below it, in order to create the drop target.